### PR TITLE
refactor(api,basic): replace showRoutes

### DIFF
--- a/templates/api/app/server.ts
+++ b/templates/api/app/server.ts
@@ -1,7 +1,8 @@
 import { createApp } from 'sonik/default'
+import { showRoutes } from "hono/dev"
 
 const app = createApp()
 
-app.showRoutes()
+showRoutes(app)
 
 export default app

--- a/templates/basic/app/server.ts
+++ b/templates/basic/app/server.ts
@@ -1,9 +1,10 @@
 import { createApp } from 'sonik/default'
 import { serveStatic } from 'hono/cloudflare-pages'
+import { showRoutes } from "hono/dev"
 
 const app = createApp()
 app.use('/static/*', serveStatic())
 
-app.showRoutes()
+showRoutes(app)
 
 export default app


### PR DESCRIPTION
`app.showRoutes` is deprecated. Replaced with version from `hono/dev`